### PR TITLE
fix: mail confusion with names

### DIFF
--- a/src/chat/interfaces/chat-task-manager.ts
+++ b/src/chat/interfaces/chat-task-manager.ts
@@ -39,7 +39,7 @@ export interface ChatTaskManager<A extends Actor = Actor> {
    */
   createGetTask(actor: A, objectId: string): Task<A, Chat>;
 
-  createGetTaskSequence(actor: A, objectId: string): Task<Actor, unknown>[];
+  createGetTaskSequence(actor: A, objectId: string): Task<A, unknown>[];
 
   /**
    * Factory for a task to publish a message in a chat

--- a/src/mentions/interfaces/chat-mentions-task-manager.ts
+++ b/src/mentions/interfaces/chat-mentions-task-manager.ts
@@ -1,11 +1,11 @@
-import { Actor, Task } from '@graasp/sdk';
+import { Member, Task } from '@graasp/sdk';
 
 import { MemberChatMentions } from './chat-mention';
 
 /**
  * Task manager for chat operations
  */
-export interface ChatMentionsTaskManager<A extends Actor = Actor> {
+export interface ChatMentionsTaskManager<A extends Member = Member> {
   /**
    * Returns the name of the create mention task (write)
    */

--- a/src/mentions/mailer-hooks.ts
+++ b/src/mentions/mailer-hooks.ts
@@ -22,10 +22,12 @@ export function registerChatMentionsMailerHooks(
   const sendMentionNotificationEmail = ({
     item,
     member,
+    mentionCreator,
     log,
   }: {
     item: Item;
     member: Member;
+    mentionCreator: Member;
     log: FastifyLoggerInstance;
   }) => {
     const itemLink = buildItemLinkForBuilder({
@@ -40,7 +42,7 @@ export function registerChatMentionsMailerHooks(
         member,
         itemLink,
         item.name,
-        member.name,
+        mentionCreator.name,
         lang,
       )
       .catch((err) => {
@@ -55,15 +57,17 @@ export function registerChatMentionsMailerHooks(
     createMentionsTaskName,
     (
       _,
-      __,
+      mentionCreator,
       { log },
       { mentionedUsers, item }: { mentionedUsers: Member[]; item: Item },
     ) => {
+      const creator = mentionCreator as Member;
       // send email to notify users
       mentionedUsers.forEach((mentionedUser) => {
         sendMentionNotificationEmail({
           item,
           member: mentionedUser,
+          mentionCreator: creator,
           log,
         });
       });

--- a/src/mentions/mailer-hooks.ts
+++ b/src/mentions/mailer-hooks.ts
@@ -47,7 +47,7 @@ export function registerChatMentionsMailerHooks(
       )
       .catch((err) => {
         log.warn(err, `mailer failed. notification link: ${itemLink}`);
-        log.warn(member, 'mentioned by', mentionCreator);
+        console.log(member, 'mentioned by', mentionCreator);
       });
   };
 

--- a/src/mentions/mailer-hooks.ts
+++ b/src/mentions/mailer-hooks.ts
@@ -47,6 +47,7 @@ export function registerChatMentionsMailerHooks(
       )
       .catch((err) => {
         log.warn(err, `mailer failed. notification link: ${itemLink}`);
+        log.warn(member, 'mentioned by', mentionCreator);
       });
   };
 

--- a/src/mentions/mailer-hooks.ts
+++ b/src/mentions/mailer-hooks.ts
@@ -47,7 +47,6 @@ export function registerChatMentionsMailerHooks(
       )
       .catch((err) => {
         log.warn(err, `mailer failed. notification link: ${itemLink}`);
-        console.log(member, 'mentioned by', mentionCreator);
       });
   };
 
@@ -62,6 +61,8 @@ export function registerChatMentionsMailerHooks(
       { log },
       { mentionedUsers, item }: { mentionedUsers: Member[]; item: Item },
     ) => {
+      // casting here because the runner assumes the passed argument is a simple actor
+      // but with mentions the user is always logged in so it resolves to a Member
       const creator = mentionCreator as Member;
       // send email to notify users
       mentionedUsers.forEach((mentionedUser) => {

--- a/src/mentions/task-manager.ts
+++ b/src/mentions/task-manager.ts
@@ -1,5 +1,4 @@
 import {
-  Actor,
   ItemMembershipService,
   ItemMembershipTaskManager,
   ItemService,
@@ -63,7 +62,9 @@ export class TaskManager implements ChatMentionsTaskManager {
     return ClearAllMentionsTask.name;
   }
 
-  createGetMemberMentionsTask(member: Actor): Task<Actor, MemberChatMentions> {
+  createGetMemberMentionsTask(
+    member: Member,
+  ): Task<Member, MemberChatMentions> {
     return new GetMemberMentionsTask(member, this.mentionService);
   }
 
@@ -71,7 +72,7 @@ export class TaskManager implements ChatMentionsTaskManager {
     member: Member,
     mentionId: string,
     status: MentionStatus,
-  ): Task<Actor, unknown>[] {
+  ): Task<Member, unknown>[] {
     const t1 = new IsOwnMentionTask(member, mentionId, this.mentionService);
     const t2 = new UpdateMentionStatusTask(
       member,
@@ -88,13 +89,13 @@ export class TaskManager implements ChatMentionsTaskManager {
   createDeleteMentionTaskSequence(
     member: Member,
     mentionId: string,
-  ): Task<Actor, unknown>[] {
+  ): Task<Member, unknown>[] {
     const t1 = new IsOwnMentionTask(member, mentionId, this.mentionService);
     const t2 = new DeleteMentionTask(member, mentionId, this.mentionService);
     return [t1, t2];
   }
 
-  createClearAllMentionsTaskSingle(member: Member): Task<Actor, unknown> {
+  createClearAllMentionsTaskSingle(member: Member): Task<Member, unknown> {
     return new ClearAllMentionsTask(member, this.mentionService);
   }
 }

--- a/src/mentions/tasks/base-mention-task.ts
+++ b/src/mentions/tasks/base-mention-task.ts
@@ -1,9 +1,9 @@
 import { FastifyLoggerInstance } from 'fastify';
 
 import {
-  Actor,
   DatabaseTransactionHandler,
   IndividualResultType,
+  Member,
   PostHookHandlerType,
   PreHookHandlerType,
   Task,
@@ -15,12 +15,12 @@ import { MentionService } from '../db-service';
 /**
  * Abstract base task definition for operations on the chat database
  */
-export abstract class BaseMentionTask<R> implements Task<Actor, R> {
+export abstract class BaseMentionTask<R> implements Task<Member, R> {
   protected mentionService: MentionService;
   protected _result: R;
   protected _message: string;
 
-  readonly actor: Actor;
+  readonly actor: Member;
 
   status: TaskStatus;
   targetId: string;
@@ -34,7 +34,7 @@ export abstract class BaseMentionTask<R> implements Task<Actor, R> {
   getInput?: () => unknown;
   getResult?: () => unknown;
 
-  constructor(actor: Actor, mentionService: MentionService) {
+  constructor(actor: Member, mentionService: MentionService) {
     this.actor = actor;
     this.status = TaskStatus.NEW;
     this.mentionService = mentionService;

--- a/src/mentions/tasks/clear-all-mentions-task.ts
+++ b/src/mentions/tasks/clear-all-mentions-task.ts
@@ -1,6 +1,6 @@
 import { FastifyLoggerInstance } from 'fastify';
 
-import { Actor, DatabaseTransactionHandler, TaskStatus } from '@graasp/sdk';
+import { DatabaseTransactionHandler, Member, TaskStatus } from '@graasp/sdk';
 
 import { MentionService } from '../db-service';
 import { MemberChatMentions } from '../interfaces/chat-mention';
@@ -14,7 +14,7 @@ export class ClearAllMentionsTask extends BaseMentionTask<MemberChatMentions> {
     return ClearAllMentionsTask.name;
   }
 
-  constructor(member: Actor, mentionService: MentionService) {
+  constructor(member: Member, mentionService: MentionService) {
     super(member, mentionService);
     this.targetId = member.id;
   }

--- a/src/mentions/tasks/delete-mention-task.ts
+++ b/src/mentions/tasks/delete-mention-task.ts
@@ -1,6 +1,6 @@
 import { FastifyLoggerInstance } from 'fastify';
 
-import { Actor, DatabaseTransactionHandler, TaskStatus } from '@graasp/sdk';
+import { DatabaseTransactionHandler, Member, TaskStatus } from '@graasp/sdk';
 
 import { MentionService } from '../db-service';
 import { ChatMention } from '../interfaces/chat-mention';
@@ -15,7 +15,7 @@ export class DeleteMentionTask extends BaseMentionTask<ChatMention> {
   }
 
   constructor(
-    member: Actor,
+    member: Member,
     mentionId: string,
     mentionService: MentionService,
   ) {

--- a/src/mentions/tasks/get-mentions-task.ts
+++ b/src/mentions/tasks/get-mentions-task.ts
@@ -1,6 +1,6 @@
 import { FastifyLoggerInstance } from 'fastify';
 
-import { Actor, DatabaseTransactionHandler, TaskStatus } from '@graasp/sdk';
+import { DatabaseTransactionHandler, Member, TaskStatus } from '@graasp/sdk';
 
 import { MentionService } from '../db-service';
 import { MemberChatMentions } from '../interfaces/chat-mention';
@@ -14,7 +14,7 @@ export class GetMemberMentionsTask extends BaseMentionTask<MemberChatMentions> {
     return GetMemberMentionsTask.name;
   }
 
-  constructor(member: Actor, mentionService: MentionService) {
+  constructor(member: Member, mentionService: MentionService) {
     super(member, mentionService);
     this.targetId = member.id;
   }

--- a/src/mentions/tasks/is-own-mention-task.ts
+++ b/src/mentions/tasks/is-own-mention-task.ts
@@ -1,4 +1,4 @@
-import { Actor, DatabaseTransactionHandler, TaskStatus } from '@graasp/sdk';
+import { DatabaseTransactionHandler, Member, TaskStatus } from '@graasp/sdk';
 
 import { MemberCannotEditMention } from '../../util/graasp-item-chat-error';
 import { MentionService } from '../db-service';
@@ -14,7 +14,7 @@ export class IsOwnMentionTask extends BaseMentionTask<ChatMention> {
   }
 
   constructor(
-    member: Actor,
+    member: Member,
     mentionId: string,
     mentionService: MentionService,
   ) {

--- a/src/mentions/tasks/update-mention-status-task.ts
+++ b/src/mentions/tasks/update-mention-status-task.ts
@@ -1,8 +1,8 @@
 import { FastifyLoggerInstance } from 'fastify';
 
 import {
-  Actor,
   DatabaseTransactionHandler,
+  Member,
   MentionStatus,
   TaskStatus,
 } from '@graasp/sdk';
@@ -28,7 +28,7 @@ export class UpdateMentionStatusTask extends BaseMentionTask<ChatMention> {
   }
 
   constructor(
-    member: Actor,
+    member: Member,
     mentionId: string,
     mentionService: MentionService,
     input: InputType,

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,7 +833,7 @@ __metadata:
 
 "@graasp/sdk@github:graasp/graasp-sdk":
   version: 0.1.0
-  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=5170aab6390aa6deb16b9be559a359bdec050cc9"
+  resolution: "@graasp/sdk@https://github.com/graasp/graasp-sdk.git#commit=41b8c166b4a4db98259e56797f9b1f56e1b40465"
   dependencies:
     "@fastify/secure-session": 5.2.0
     aws-sdk: 2.1111.0
@@ -844,7 +844,7 @@ __metadata:
     qs: 6.11.0
     slonik: 28.1.1
     uuid: 8.3.2
-  checksum: 4548423660f7c7d57f07ae1fa3d243e80d516f03bddd04c23df707aabe9302b671f22e17f318c48414960921a3fd9ee5144e0f0da057d070879923f1a0389edf
+  checksum: e3d9523f5b6ea307a1ed5dfcf7827addf2f16a8b01220dd0ad6ebcda7d28dbd93ac4caacd76f3d8159bec5f4c02395713cc874e18e795bfc7a65a2b8ea494496
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes a bug in the emails where when A mentions B the email would say "B mentioned B" instead of "A mentioned B".

closes #36 